### PR TITLE
依照Guideline設定字體並建立base檔案

### DIFF
--- a/assets/scss/all.scss
+++ b/assets/scss/all.scss
@@ -2,8 +2,11 @@
 @import"./helpers/variables"; //匯入
 @import"./helpers/variables-dark"; //匯入
 @import "../../node_modules/bootstrap";
-@import"./helpers/utilities"; //匯入
 
+@import"./helpers/utilities"; //匯入
+@import "../../node_modules/bootstrap/scss/utilities/api"; //匯入
+
+@import './base/base'; //匯入
 
 
 @import './layout/header.scss';

--- a/assets/scss/base/_base.scss
+++ b/assets/scss/base/_base.scss
@@ -1,0 +1,34 @@
+// 匯入字體來源：https://github.com/max32002/FakePearl
+@font-face {
+  font-family: "FakePearl-Regular";
+  src: url("https://cdn.jsdelivr.net/gh/max32002/FakePearl@1.1/webfont/FakePearl-Regular.woff2") format("woff2"), url("https://cdn.jsdelivr.net/gh/max32002/FakePearl@1.1/webfont/FakePearl-Regular.woff") format("woff");
+}
+
+// 設定整體字體為自訂字體：FakePearl-Regular，若有些系統無法使用則改為用BS設定在variables檔案的原訂字體
+body{
+  font-family: "FakePearl-Regular", $font-family-sans-serif;
+}
+
+// 圖片RWD調整
+img{
+  max-width: 100%;
+  height: auto;
+}
+
+// a連結調整
+a{
+  color: inherit; // 讓文字顏色繼承父層設定
+  display: inline-block;
+}
+
+// 依照guideline調整h2和h5標籤預設的字距、h5和h6行高
+h2{
+  letter-spacing: 0.12em;
+}
+h5{
+  letter-spacing: 0.1em;
+  line-height: 1.5;
+}
+h6{
+  line-height: 1.5;
+}

--- a/assets/scss/helpers/_utilities.scss
+++ b/assets/scss/helpers/_utilities.scss
@@ -504,9 +504,11 @@ $utilities: map-merge(
       class: font,
       values: (monospace: var(--#{$prefix}font-monospace))
     ),
+    // 自訂移除rfs開啟rwd設定
     "font-size": (
-      rfs: true,
+      // rfs: true, //移除原本rfs設定
       property: font-size,
+      responsive: true, //新增開啟rwd的設定
       class: fs,
       values: $font-sizes
     ),
@@ -807,4 +809,18 @@ $utilities: map-merge(
     // scss-docs-end utils-zindex
   ),
   $utilities
+);
+
+// 自訂要開啟rwd的通用樣式，開啟後可以用lg、md、sm來控制，讓不同斷點改成不同樣式
+$utilities: map-merge(
+  $utilities,
+  (
+    "font-size":
+      map-merge(
+        map-get($utilities, "font-size"),
+        (
+          responsive: true,
+        )
+      ),
+  )
 );

--- a/assets/scss/helpers/_variables.scss
+++ b/assets/scss/helpers/_variables.scss
@@ -482,7 +482,9 @@ $enable-grid-classes:         true !default;
 $enable-container-classes:    true !default;
 $enable-cssgrid:              false !default;
 $enable-button-pointers:      true !default;
-$enable-rfs:                  true !default;
+// 自訂移除rfs效果
+$enable-rfs:                  false !default;
+// $enable-rfs:                  true !default; //原本設定
 $enable-validation-icons:     true !default;
 $enable-negative-margins:     false !default;
 $enable-deprecation-messages: true !default;

--- a/assets/scss/helpers/_variables.scss
+++ b/assets/scss/helpers/_variables.scss
@@ -752,15 +752,29 @@ $font-weight-bolder:          bolder !default;
 $font-weight-base:            $font-weight-normal !default;
 
 $line-height-base:            1.5 !default;
-$line-height-sm:              1.25 !default;
+// 自訂行高
+$line-height-sm:              1.2 !default;
+// $line-height-sm:              1.25 !default; //原本行高設定
 $line-height-lg:              2 !default;
 
-$h1-font-size:                $font-size-base * 2.5 !default;
-$h2-font-size:                $font-size-base * 2 !default;
-$h3-font-size:                $font-size-base * 1.75 !default;
-$h4-font-size:                $font-size-base * 1.5 !default;
-$h5-font-size:                $font-size-base * 1.25 !default;
-$h6-font-size:                $font-size-base !default;
+
+// 自訂字體大小
+$h1-font-size:                $font-size-base * 3.8125 !default;
+$h2-font-size:                $font-size-base * 3.0625 !default;
+$h3-font-size:                $font-size-base * 2.4375 !default;
+$h4-font-size:                $font-size-base * 1.9375 !default;
+$h5-font-size:                $font-size-base * 1.5625 !default;
+$h6-font-size:                $font-size-base * 1.25 !default;
+$h7-font-size:                $font-size-base !default;
+$h8-font-size:                $font-size-base * 0.8125 !default;
+
+ //原本字體大小設定
+// $h1-font-size:                $font-size-base * 2.5 !default;
+// $h2-font-size:                $font-size-base * 2 !default;
+// $h3-font-size:                $font-size-base * 1.75 !default;
+// $h4-font-size:                $font-size-base * 1.5 !default;
+// $h5-font-size:                $font-size-base * 1.25 !default;
+// $h6-font-size:                $font-size-base !default;
 // scss-docs-end font-variables
 
 // scss-docs-start font-sizes
@@ -770,7 +784,9 @@ $font-sizes: (
   3: $h3-font-size,
   4: $h4-font-size,
   5: $h5-font-size,
-  6: $h6-font-size
+  6: $h6-font-size,
+  7: $h7-font-size,
+  8: $h8-font-size
 ) !default;
 // scss-docs-end font-sizes
 

--- a/assets/scss/helpers/_variables.scss
+++ b/assets/scss/helpers/_variables.scss
@@ -794,7 +794,9 @@ $font-sizes: (
 $headings-margin-bottom:      $spacer * .5 !default;
 $headings-font-family:        null !default;
 $headings-font-style:         null !default;
-$headings-font-weight:        500 !default;
+//自訂字重400
+$headings-font-weight:        400 !default;
+// $headings-font-weight:        500 !default; //原本的字重
 $headings-line-height:        1.2 !default;
 $headings-color:              inherit !default;
 // scss-docs-end headings-variables

--- a/pages/index.html
+++ b/pages/index.html
@@ -44,6 +44,10 @@
     <h5>h5標籤預設大小25px、行高1.5(37.5px)、字重400、字距0.1em(2.5px)</h5>
     <h6>h6標籤預設大小20px、行高1.5(30px)、字重400</h6>
 
+    <hr>
+
+    <!-- 測試字體大小的rwd斷點有沒有作用 -->
+    <p class="fs-lg-4 fs-6">桌面版字體大小31px、手機版字體大小20px</p>
 
     <!-- <div class="card" style="width: 18rem">
       <img src="../assets/images/cat.jpg" class="card-img-top" alt="cat" />

--- a/pages/index.html
+++ b/pages/index.html
@@ -7,29 +7,45 @@
     <title>index</title>
   </head>
   <body>
-    <%- include('./layout/header'); -%>
+    <!-- <%- include('./layout/header'); -%>
 
-    <h1 class="index-title text-primary-100">我是首頁</h1>
+    <h1 class="index-title text-primary-100">我是首頁</h1> -->
 
-    <!-- 測試用variable自訂字體大小有沒有套成功 -->
-    <h1 class="fs-1">h1標題</h1>
-    <h2 class="fs-2">h2標題</h2>
-    <h3 class="fs-3">h3標題</h3>
-    <h4 class="fs-4">h4標題</h4>
-    <h5 class="fs-5">h5標題</h5>
-    <h6 class="fs-6">h6標題</h6>
-    <p class="fs-7">Lorem ipsum dolor sit amet consectetur adipisicing elit. Neque, odit, iusto odio assumenda alias id
-    nobis earum!</p>
-    <p class="fs-8">Lorem ipsum dolor sit amet consectetur adipisicing elit. Neque, odit, iusto odio assumenda alias id
-    nobis earum!</p>
+    <!-- 測試variable自訂字體大小有沒有套成功 -->
+    <h1 class="fs-1">fs-1字體大小61px</h1>
+    <h2 class="fs-2">fs-2標題字體大小49px</h2>
+    <h3 class="fs-3">fs-3標題字體大小39px</h3>
+    <h4 class="fs-4">fs-4標題字體大小31px</h4>
+    <h5 class="fs-5">fs-5標題字體大小25px</h5>
+    <h6 class="fs-6">fs-6標題字體大小20px</h6>
+    <p class="fs-7">fs-7字體大小16px</p>
+    <p class="fs-8">fs-8字體大小13px</p>
+
+    <hr>
     
-    <!-- 測試用variable自訂行高有沒有套成功 -->
-    <p class="lh-sm">Lorem ipsum dolor sit amet consectetur adipisicing elit. Neque, odit, iusto odio assumenda alias id
-      nobis earum!</p>
-    <h5 class="lh-base">Lorem ipsum dolor sit amet consectetur adipisicing elit. Neque, odit, iusto odio assumenda alias id
-      nobis earum!</h5>
+    <!-- 測試variable自訂行高有沒有套成功 -->
+    <p class="lh-sm">lh-sm行高1.2(19.2px)</p>
+    <h4 class="lh-base">lh-base行高1.5(46.5px)</h4>
 
-    <div class="card" style="width: 18rem">
+    <hr>
+
+    <!-- 測試以下標籤預設字體設定是多少 -->
+    <p>p標籤預設大小16px、行高1.5(24px)、字重400</p>
+
+    <ul>
+      <li>li標籤預設大小16px、行高1.5(24px)、字重400</li>
+      <li>li標籤預設大小16px、行高1.5(24px)、字重400</li>
+    </ul>
+
+    <h1>h1標籤預設大小61px、行高1.2(73.2px)、字重400</h1>
+    <h2>h2標籤預設大小49px、行高1.2(58.8px)、字重400、字距0.12em(5.88px)</h2>
+    <h3>h3標籤預設大小39px、行高1.2(46.8px)、字重400</h3>
+    <h4>h4標籤預設大小31px、行高1.2(37.2px)、字重400</h4>
+    <h5>h5標籤預設大小25px、行高1.5(37.5px)、字重400、字距0.1em(2.5px)</h5>
+    <h6>h6標籤預設大小20px、行高1.5(30px)、字重400</h6>
+
+
+    <!-- <div class="card" style="width: 18rem">
       <img src="../assets/images/cat.jpg" class="card-img-top" alt="cat" />
       <div class="card-body">
         <h5 class="card-title">卡片元件</h5>
@@ -38,15 +54,15 @@
           nobis earum!
         </p>
       </div>
-    </div>
+    </div> -->
 
     <!-- Modal 按鈕 -->
-    <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#exampleModal">
+    <!-- <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#exampleModal">
       打開 modal
-    </button>
+    </button> -->
 
     <!-- Modal 元件 -->
-    <div
+    <!-- <div
       class="modal fade"
       id="exampleModal"
       tabindex="-1"
@@ -66,9 +82,9 @@
           </div>
         </div>
       </div>
-    </div>
+    </div> -->
 
-    <%- include('./layout/footer'); -%>
+    <!-- <%- include('./layout/footer'); -%> -->
 
     <script type="module" src="../main.js"></script>
   </body>

--- a/pages/index.html
+++ b/pages/index.html
@@ -11,6 +11,24 @@
 
     <h1 class="index-title text-primary-100">我是首頁</h1>
 
+    <!-- 測試用variable自訂字體大小有沒有套成功 -->
+    <h1 class="fs-1">h1標題</h1>
+    <h2 class="fs-2">h2標題</h2>
+    <h3 class="fs-3">h3標題</h3>
+    <h4 class="fs-4">h4標題</h4>
+    <h5 class="fs-5">h5標題</h5>
+    <h6 class="fs-6">h6標題</h6>
+    <p class="fs-7">Lorem ipsum dolor sit amet consectetur adipisicing elit. Neque, odit, iusto odio assumenda alias id
+    nobis earum!</p>
+    <p class="fs-8">Lorem ipsum dolor sit amet consectetur adipisicing elit. Neque, odit, iusto odio assumenda alias id
+    nobis earum!</p>
+    
+    <!-- 測試用variable自訂行高有沒有套成功 -->
+    <p class="lh-sm">Lorem ipsum dolor sit amet consectetur adipisicing elit. Neque, odit, iusto odio assumenda alias id
+      nobis earum!</p>
+    <h5 class="lh-base">Lorem ipsum dolor sit amet consectetur adipisicing elit. Neque, odit, iusto odio assumenda alias id
+      nobis earum!</h5>
+
     <div class="card" style="width: 18rem">
       <img src="../assets/images/cat.jpg" class="card-img-top" alt="cat" />
       <div class="card-body">


### PR DESCRIPTION
一、在 helpers 資料夾中的 _variables.scss 檔案中作了以下調整

1. 字體大小(font-size)：有註解請搜尋【自訂字體大小】，這邊調整的字體大小會影響 **fs-1~fs-8 這8個 class 的設定** (h1~h6標籤的預設字體大小也會同步調整)
2. 行高(line-height)：有註解請搜尋【自訂行高】，把 $line-height-sm 改為 1.2，之後如果要把行高改為 1.2 就加入 lh-sm 這個 class就可以了
3. 字重(font-weight)：有註解請搜尋【自訂字重400】，把 $headings-font-weight 改為 400，因為 Guideline 字重都是 400
4. 移除rfs效果：有註解請搜尋【自訂移除rfs效果】，把 $enable-rfs 改為 false，讓文字大小不會依照畫面自動調整

二、在 helpers 資料夾中的 _utilities.scss 檔案中作了以下調整

1. 移除rfs效果：有註解請搜尋【自訂移除rfs開啟rwd設定】，把 rfs: true, 註解掉，讓文字大小不會依照畫面自動調整，再新增 responsive: true, 開啟 font-size(fs) 的 rwd 設定
2. 讓 font-size(fs) 開啟 rwd 設定：共新增在2個位置，有註解請搜尋【自訂要開啟rwd的通用樣式】，新增程式碼(助教解說提供的)，讓 font-size(fs) 可以用 bs 提供的 lg、md、sm 等斷點，讓不同斷點改成不同文字大小，之後如果有其他通用樣式要新增這個功能可以參考 font-size 的設定方式

三、新增 base 資料夾在裡面新增 _base.scss 檔案並新增以下內容

1. 匯入字體：有註解請搜尋【匯入字體來源】，所用字體的 [GitHub 連結](https://github.com/max32002/FakePearl)，依照連結說明匯入字體，他說明的 code 沒有加雙引號，上網搜尋是要加入的所以有補上缺漏的雙引號
2. 設定整體字體為自訂字體：有註解請搜尋【設定整體字體為自訂字體】，設定網頁預設字體為 "FakePearl-Regular" ，後面有逗號再加上變數 $font-family-sans-serif ，這個變數是在 _variables.scss 檔案中設定的 (bs的預設字體)，為避免在某些裝置上無法使用 "FakePearl-Regular" 這個自訂字體，保險起見加入 bs 的預設字體變數：$font-family-sans-serif 
3. 基本調整：有註解請搜尋【圖片RWD調整】和【a連結調整】，這是參考助教任務六直播，針對 img 和 a 標籤做了基本調整
4. 調整 h2、h5 的字距和 h5、h6 的行高：有註解請搜尋【依照guideline調整h2和h5標籤預設的字距、h5和h6行高】，發現 Guideline 有個別設定某幾個標籤的字距及行高和預設不同，所以做了調整
5. 補充說明：bs 的預設行高 h1~h6 標籤都是 1.2，p、li 標籤都是 1.5

四、為了測試我改了 index.html 檔案

我把每個修改好的 class 都套看看，也測試沒有加任何 class 的情況下 h1~h6 、p、li 標籤的文字設定，為了避免畫面太亂所以先把 Vite 預設的首頁內容註解掉了

附上我的git線圖
![image](https://github.com/user-attachments/assets/ee1a9cab-be4e-46ca-bda4-aa75808d11cb)
